### PR TITLE
FIX: Using google parameter for google template

### DIFF
--- a/Resources/config/security_google.xml
+++ b/Resources/config/security_google.xml
@@ -23,7 +23,7 @@
 			<argument type="service" id="scheb_two_factor.security.google_authenticator" />
 			<argument type="service" id="security.context" />
 			<argument type="service" id="templating" />
-			<argument>%scheb_two_factor.email.template%</argument>
+			<argument>%scheb_two_factor.google.template%</argument>
 		</service>
 	</services>
 </container>


### PR DESCRIPTION
Code was incorrectly using the email template for the google form.
