### PR TITLE
add the "trusted computer" feature

### DIFF
--- a/Model/Email/TwoFactorInterface.php
+++ b/Model/Email/TwoFactorInterface.php
@@ -31,4 +31,14 @@ interface TwoFactorInterface
      * @param integer $authCode
      */
     public function setEmailAuthCode($authCode);
+
+    /**
+     * @param string $trustedComputerIdentifier
+     */
+    public function setTrustedComputerIdentifier($trustedComputerIdentifier);
+
+    /**
+     * @return string
+     */
+    public function getTrustedComputerIdentifier();
 }

--- a/Resources/config/security_email.xml
+++ b/Resources/config/security_email.xml
@@ -21,6 +21,7 @@
 		</service>
 		<service id="scheb_two_factor.security.email.request_listener" class="%scheb_two_factor.security.email.request_listener.class%">
 			<tag name="kernel.event_listener" event="kernel.request" method="onCoreRequest" priority="-1" />
+			<argument type="service" id="doctrine.orm.entity_manager" />
 			<argument type="service" id="scheb_two_factor.security.email.code_manager" />
 			<argument type="service" id="security.context" />
 			<argument type="service" id="templating" />

--- a/Resources/translations/messages.en.yml
+++ b/Resources/translations/messages.en.yml
@@ -2,3 +2,4 @@ scheb_two_factor:
     auth_code: Authentication Code
     login: Login
     code_invalid: The verification code is not valid.
+    is_trusted_computer: I am on a trusted computer

--- a/Resources/views/Authentication/form.html.twig
+++ b/Resources/views/Authentication/form.html.twig
@@ -7,6 +7,7 @@
 	<p class="label"><label for="_auth_code">{{ "scheb_two_factor.auth_code"|trans }}</label></p>
 	<p class="widget"><input id="_auth_code" type="text" autocomplete="off" name="_auth_code" /></p>
 	<p class="submit"><input type="submit" value="{{ "scheb_two_factor.login"|trans }}" /></p>
+	<p class="submit"><input type="checkbox" id="_is_trusted" name="_is_trusted" value="true" /> {{ "scheb_two_factor.is_trusted_computer"|trans }}</p>
 	
 	{# The logout link gives the user a way out if they can't complete the second step #}
 	<p class="cancel"><a href="{{ path("_security_logout") }}">Cancel</a></p>

--- a/Security/TwoFactor/Email/InteractiveLoginListener.php
+++ b/Security/TwoFactor/Email/InteractiveLoginListener.php
@@ -44,6 +44,11 @@ class InteractiveLoginListener
             return;
         }
 
+         $isTrustedCookie = $event->getRequest()->cookies->get(RequestListener::TWO_WAY_TRUSTED_COOKIE);
+         if ( $isTrustedCookie != null && $isTrustedCookie == $user->getTrustedComputerIdentifier()) {
+             return;
+         }
+
         // Set flag in the session
         $sessionFlag = sprintf('two_factor_email_%s_%s', $token->getProviderKey(), $token->getUsername());
         $event->getRequest()->getSession()->set($sessionFlag, null);


### PR DESCRIPTION
I haven't tested it yet. But this should work.

The idea is that on the second login form I can check "I am on a trusted computer" and the next time I log in, I should skip the second validation form.

This is more or less what google for their two-factor.

Hope you'll enjoy it!
