### PR TITLE
Fixing erroneous example in Google doc

### DIFF
--- a/Resources/doc/google.md
+++ b/Resources/doc/google.md
@@ -55,7 +55,7 @@ The bundle uses `Resources/views/Authentication/form.html.twig` to render the au
 
 ```yaml
 scheb_two_factor:
-    email:
+    google:
         template: AcmeDemoBundle:Authentication:my_custom_template.html.twig
 ```
 


### PR DESCRIPTION
This example was using the wrong auth option, probably a copy & paste error.