### PR TITLE
Make `is_granted` work using a SecurityVoter

### DIFF
--- a/DependencyInjection/Compiler/ProviderCompilerPass.php
+++ b/DependencyInjection/Compiler/ProviderCompilerPass.php
@@ -20,7 +20,7 @@ class ProviderCompilerPass implements CompilerPassInterface
             return;
         }
 
-        $definition = $container->getDefinition('scheb_two_factor.provider_registry');
+        $definition = $container->getDefinition('scheb_two_factor.provider_collection');
         $taggedServices = $container->findTaggedServiceIds('scheb_two_factor.provider');
         $references = array();
         foreach ($taggedServices as $id => $attributes) {
@@ -28,8 +28,10 @@ class ProviderCompilerPass implements CompilerPassInterface
                 throw new InvalidArgumentException('Tag "scheb_two_factor.provider" requires attribute "alias" to be set.');
             }
             $name = $attributes[0]['alias'];
-            $references[$name] = new Reference($id);
+            $definition->addMethodCall(
+                'addProvider',
+                array(new Reference($id))
+            );
         }
-        $definition->replaceArgument(1, $references);
     }
 }

--- a/DependencyInjection/Compiler/ProviderCompilerPass.php
+++ b/DependencyInjection/Compiler/ProviderCompilerPass.php
@@ -16,7 +16,7 @@ class ProviderCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (! $container->hasDefinition("scheb_two_factor.provider_registry")) {
+        if (! $container->hasDefinition("scheb_two_factor.provider_collection")) {
             return;
         }
 
@@ -30,7 +30,7 @@ class ProviderCompilerPass implements CompilerPassInterface
             $name = $attributes[0]['alias'];
             $definition->addMethodCall(
                 'addProvider',
-                array(new Reference($id))
+                array($name, new Reference($id))
             );
         }
     }

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -6,6 +6,7 @@
 		<parameter key="scheb_two_factor.trusted_cookie_manager.class">Scheb\TwoFactorBundle\Security\TwoFactor\Trusted\TrustedCookieManager</parameter>
 		<parameter key="scheb_two_factor.trusted_token_generator.class">Scheb\TwoFactorBundle\Security\TwoFactor\Trusted\TrustedTokenGenerator</parameter>
 		<parameter key="scheb_two_factor.trusted_filter.class">Scheb\TwoFactorBundle\Security\TwoFactor\Trusted\TrustedFilter</parameter>
+		<parameter key="scheb_two_factor.provider_collection.class">Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderCollection</parameter>
 		<parameter key="scheb_two_factor.provider_registry.class">Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderRegistry</parameter>
 		<parameter key="scheb_two_factor.backup_code_validator.class">Scheb\TwoFactorBundle\Security\TwoFactor\Backup\BackupCodeValidator</parameter>
 	</parameters>
@@ -30,9 +31,11 @@
 			<argument>%scheb_two_factor.trusted_computer.enabled%</argument>
 			<argument>%scheb_two_factor.parameter_names.trusted%</argument>
 		</service>
+		<service id="scheb_two_factor.provider_collection" class="%scheb_two_factor.provider_collection.class%">
+		</service>
 		<service id="scheb_two_factor.provider_registry" class="%scheb_two_factor.provider_registry.class%">
 			<argument type="service" id="scheb_two_factor.session_flag_manager" />
-			<argument></argument> <!-- Two-factor providers -->
+			<argument type="service" id="scheb_two_factor.provider_collection" />
 		</service>
 		<service id="scheb_two_factor.backup_code_validator" class="%scheb_two_factor.backup_code_validator.class%">
 			<argument type="service" id="scheb_two_factor.persister.doctrine" />

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -9,6 +9,7 @@
 		<parameter key="scheb_two_factor.provider_collection.class">Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderCollection</parameter>
 		<parameter key="scheb_two_factor.provider_registry.class">Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderRegistry</parameter>
 		<parameter key="scheb_two_factor.backup_code_validator.class">Scheb\TwoFactorBundle\Security\TwoFactor\Backup\BackupCodeValidator</parameter>
+		<parameter key="scheb_two_factor.security_voter.class">Scheb\TwoFactorBundle\Security\TwoFactor\Voter</parameter>
 	</parameters>
 	<services>
 		<service id="scheb_two_factor.session_flag_manager" class="%scheb_two_factor.session_flag_manager.class%">
@@ -39,6 +40,11 @@
 		</service>
 		<service id="scheb_two_factor.backup_code_validator" class="%scheb_two_factor.backup_code_validator.class%">
 			<argument type="service" id="scheb_two_factor.persister.doctrine" />
+		</service>
+		<service id="scheb_two_factor.security_voter" class="%scheb_two_factor.security_voter.class%">
+			<argument type="service" id="scheb_two_factor.session_flag_manager" />
+			<argument type="service" id="scheb_two_factor.provider_collection" />
+			<tag name="security.voter" />
 		</service>
 	</services>
 </container>

--- a/Security/TwoFactor/Provider/TwoFactorProviderCollection.php
+++ b/Security/TwoFactor/Provider/TwoFactorProviderCollection.php
@@ -1,0 +1,35 @@
+<?php
+namespace Scheb\TwoFactorBundle\Security\TwoFactor\Provider;
+
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Class TwoFactorProviderCollection
+ */
+class TwoFactorProviderCollection
+{
+    /**
+     * @var array
+     **/
+    protected $providers = array();
+
+    /**
+     * addProvider
+     * @param string                                          $name
+     * @param Symfony\Component\DependencyInjection\Reference $provider
+     * @return void
+     **/
+    public function addProvider($name, Reference $provider)
+    {
+        $this->providers[$name] = $provider;
+    }
+
+    /**
+     * getProviders
+     * @return array
+     **/
+    public function getProviders()
+    {
+        return $this->providers;
+    }
+}

--- a/Security/TwoFactor/Provider/TwoFactorProviderCollection.php
+++ b/Security/TwoFactor/Provider/TwoFactorProviderCollection.php
@@ -15,11 +15,11 @@ class TwoFactorProviderCollection
 
     /**
      * addProvider
-     * @param string                                          $name
-     * @param Symfony\Component\DependencyInjection\Reference $provider
+     * @param string $name
+     * @param mixed  $provider
      * @return void
      **/
-    public function addProvider($name, Reference $provider)
+    public function addProvider($name, $provider)
     {
         $this->providers[$name] = $provider;
     }

--- a/Security/TwoFactor/Provider/TwoFactorProviderRegistry.php
+++ b/Security/TwoFactor/Provider/TwoFactorProviderRegistry.php
@@ -26,13 +26,13 @@ class TwoFactorProviderRegistry implements AuthenticationHandlerInterface
     /**
      * Initialize with an array of registered two-factor providers
      *
-     * @param \Scheb\TwoFactorBundle\Security\TwoFactor\Session\SessionFlagManager $flagManager
-     * @param array                                                                $providers
+     * @param \Scheb\TwoFactorBundle\Security\TwoFactor\Session\SessionFlagManager           $flagManager
+     * @param \Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderCollection $providerCollection
      */
-    public function __construct(SessionFlagManager $flagManager, $providers = array())
+    public function __construct(SessionFlagManager $flagManager, $providerCollection)
     {
         $this->flagManager = $flagManager;
-        $this->providers = $providers;
+        $this->providers = $providerCollection->getProviders();
     }
 
     /**

--- a/Security/TwoFactor/Provider/TwoFactorProviderRegistry.php
+++ b/Security/TwoFactor/Provider/TwoFactorProviderRegistry.php
@@ -20,9 +20,9 @@ class TwoFactorProviderRegistry implements AuthenticationHandlerInterface
     /**
      * List of two-factor providers
      *
-     * @var array $providers
+     * @var TwoFactorProviderCollection
      */
-    private $providers;
+    private $providerCollection;
 
     /**
      * Initialize with an array of registered two-factor providers
@@ -33,7 +33,7 @@ class TwoFactorProviderRegistry implements AuthenticationHandlerInterface
     public function __construct(SessionFlagManager $flagManager, TwoFactorProviderCollection $providerCollection)
     {
         $this->flagManager = $flagManager;
-        $this->providers = $providerCollection->getProviders();
+        $this->providerCollection = $providerCollection;
     }
 
     /**
@@ -43,7 +43,7 @@ class TwoFactorProviderRegistry implements AuthenticationHandlerInterface
      */
     public function beginAuthentication(AuthenticationContext $context)
     {
-        foreach ($this->providers as $providerName => $provider) {
+        foreach ($this->providerCollection->getProviders() as $providerName => $provider) {
             if ($provider->beginAuthentication($context)) {
                 $this->flagManager->setBegin($providerName, $context->getToken());
             }
@@ -62,7 +62,7 @@ class TwoFactorProviderRegistry implements AuthenticationHandlerInterface
         $token = $context->getToken();
 
         // Iterate over two-factor providers and ask for completion
-        foreach ($this->providers as $providerName => $provider) {
+        foreach ($this->providerCollection->getProviders() as $providerName => $provider) {
             if ($this->flagManager->isNotAuthenticated($providerName, $token)) {
                 $response = $provider->requestAuthenticationCode($context);
 

--- a/Security/TwoFactor/Provider/TwoFactorProviderRegistry.php
+++ b/Security/TwoFactor/Provider/TwoFactorProviderRegistry.php
@@ -4,6 +4,7 @@ namespace Scheb\TwoFactorBundle\Security\TwoFactor\Provider;
 use Scheb\TwoFactorBundle\Security\TwoFactor\AuthenticationHandlerInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Session\SessionFlagManager;
 use Scheb\TwoFactorBundle\Security\TwoFactor\AuthenticationContext;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderCollection;
 use Symfony\Component\HttpFoundation\Response;
 
 class TwoFactorProviderRegistry implements AuthenticationHandlerInterface
@@ -29,7 +30,7 @@ class TwoFactorProviderRegistry implements AuthenticationHandlerInterface
      * @param \Scheb\TwoFactorBundle\Security\TwoFactor\Session\SessionFlagManager           $flagManager
      * @param \Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderCollection $providerCollection
      */
-    public function __construct(SessionFlagManager $flagManager, $providerCollection)
+    public function __construct(SessionFlagManager $flagManager, TwoFactorProviderCollection $providerCollection)
     {
         $this->flagManager = $flagManager;
         $this->providers = $providerCollection->getProviders();

--- a/Security/TwoFactor/Voter.php
+++ b/Security/TwoFactor/Voter.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Scheb\TwoFactorBundle\Security\TwoFactor;
+
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Session\SessionFlagManager;
+
+/**
+ * Class Voter
+ */
+class Voter implements VoterInterface
+{
+    /**
+     * @var SessionFlagManager
+     **/
+    protected $sessionFlagManager;
+
+    /**
+     * @var array
+     **/
+    protected $providers;
+
+    /**
+     * __construct
+     * @param SessionFlagManager          $sessionFlagManager
+     * @param TwoFactorProviderCollection $providers
+     * @return void
+     **/
+    public function __construct(SessionFlagManager $sessionFlagManager, TwoFactorProviderCollection $providerCollection)
+    {
+        $this->sessionFlagManager = $sessionFlagManager;
+        $this->providers = $providerCollection->getProviders();
+    }
+
+    /**
+     * supportsClass
+     * @param string $class
+     * @return boolean true
+     **/
+    public function supportsClass($class)
+    {
+        return true;
+    }
+
+    /**
+     * supportsAttribute
+     * @param string $attribute
+     * @return boolean true
+     **/
+    public function supportsAttribute($attribute)
+    {
+        return true;
+    }
+
+    /**
+     * vote
+     * @param TokenInterface $token
+     * @param mixed          $object
+     * @param array          $attributes
+     * @return mixed result
+     **/
+    public function vote(TokenInterface $token, $object, array $attributes)
+    {
+        foreach ($this->providers as $providerName => $provider) {
+            $res = $this->sessionFlagManager->isNotAuthenticated($providerName, $token);
+            if (true === $res) {
+                return VoterInterface::ACCESS_DENIED;
+            }
+        }
+        return VoterInterface::ACCESS_ABSTAIN;
+    }
+}
+

--- a/Security/TwoFactor/Voter.php
+++ b/Security/TwoFactor/Voter.php
@@ -18,9 +18,9 @@ class Voter implements VoterInterface
     protected $sessionFlagManager;
 
     /**
-     * @var array
+     * @var TwoFactorProviderCollection
      **/
-    protected $providers;
+    protected $providerCollection;
 
     /**
      * __construct
@@ -31,7 +31,7 @@ class Voter implements VoterInterface
     public function __construct(SessionFlagManager $sessionFlagManager, TwoFactorProviderCollection $providerCollection)
     {
         $this->sessionFlagManager = $sessionFlagManager;
-        $this->providers = $providerCollection->getProviders();
+        $this->providerCollection = $providerCollection;
     }
 
     /**
@@ -63,7 +63,7 @@ class Voter implements VoterInterface
      **/
     public function vote(TokenInterface $token, $object, array $attributes)
     {
-        foreach ($this->providers as $providerName => $provider) {
+        foreach ($this->providerCollection->getProviders() as $providerName => $provider) {
             $res = $this->sessionFlagManager->isNotAuthenticated($providerName, $token);
             if (true === $res) {
                 return VoterInterface::ACCESS_DENIED;

--- a/Security/TwoFactor/Voter.php
+++ b/Security/TwoFactor/Voter.php
@@ -5,6 +5,7 @@ namespace Scheb\TwoFactorBundle\Security\TwoFactor;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Session\SessionFlagManager;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderCollection;
 
 /**
  * Class Voter

--- a/Tests/DependencyInjection/Compiler/ProviderCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ProviderCompilerPassTest.php
@@ -38,12 +38,12 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
         $this->container
             ->expects($this->once())
             ->method("hasDefinition")
-            ->with("scheb_two_factor.provider_registry")
+            ->with("scheb_two_factor.provider_collection")
             ->will($this->returnValue(true));
         $this->container
             ->expects($this->once())
             ->method("getDefinition")
-            ->with("scheb_two_factor.provider_registry")
+            ->with("scheb_two_factor.provider_collection")
             ->will($this->returnValue($this->definition));
         $this->container
             ->expects($this->once())
@@ -68,7 +68,7 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
         $this->container
             ->expects($this->once())
             ->method("hasDefinition")
-            ->with("scheb_two_factor.provider_registry")
+            ->with("scheb_two_factor.provider_collection")
             ->will($this->returnValue(false));
         $this->container
             ->expects($this->never())
@@ -80,7 +80,7 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function process_noTaggedServices_replaceArgumentWithEmptyArray()
+    public function process_noTaggedServices_noProviderAddedToCollection()
     {
         $this->createServiceDefinition();
         $taggedServices = array();
@@ -88,9 +88,8 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
 
         //Mock the Definition
         $this->definition
-            ->expects($this->once())
-            ->method("replaceArgument")
-            ->with(1, array());
+            ->expects($this->never())
+            ->method("addMethodCall");
 
         $this->compilerPass->process($this->container);
     }
@@ -98,7 +97,7 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function process_taggedServices_replaceArgumentWithServiceList()
+    public function process_taggedServices_addProviderToCollection()
     {
         $this->createServiceDefinition();
         $taggedServices = array('serviceId' => array(
@@ -109,8 +108,8 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
         //Mock the Definition
         $this->definition
             ->expects($this->once())
-            ->method("replaceArgument")
-            ->with(1, array('providerAlias' => new Reference("serviceId")));
+            ->method("addMethodCall")
+            ->with('addProvider', array('providerAlias', new Reference("serviceId")));
 
         $this->compilerPass->process($this->container);
     }

--- a/Tests/Security/TwoFactor/Provider/TwoFactorProviderCollectionTest.php
+++ b/Tests/Security/TwoFactor/Provider/TwoFactorProviderCollectionTest.php
@@ -1,0 +1,34 @@
+<?php
+namespace Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Provider;
+
+use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderCollection;
+
+class TwoFactorProviderCollectionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function addProvider_getProviders()
+    {
+        $collection = new TwoFactorProviderCollection();
+        $provider = $this->getMock("Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderInterface");
+
+        $collection->addProvider('test', $provider);
+
+        $providers = $collection->getProviders();
+
+        $this->assertEquals(array('test' => $provider), $providers);
+    }
+
+    /**
+     * @test
+     */
+    public function noProvider_getProviders()
+    {
+        $collection = new TwoFactorProviderCollection();
+
+        $providers = $collection->getProviders();
+
+        $this->assertEquals(array(), $providers);
+    }
+}

--- a/Tests/Security/TwoFactor/Provider/TwoFactorProviderRegistryTest.php
+++ b/Tests/Security/TwoFactor/Provider/TwoFactorProviderRegistryTest.php
@@ -2,6 +2,7 @@
 namespace Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Provider;
 
 use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderRegistry;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderCollection;
 use Symfony\Component\HttpFoundation\Response;
 
 class TwoFactorProviderRegistryTest extends \PHPUnit_Framework_TestCase
@@ -21,6 +22,11 @@ class TwoFactorProviderRegistryTest extends \PHPUnit_Framework_TestCase
      */
     private $registry;
 
+    /**
+     * @var \Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderCollection
+     **/
+    protected $collection;
+
     public function setUp()
     {
         $this->flagManager = $this->getMockBuilder("Scheb\TwoFactorBundle\Security\TwoFactor\Session\SessionFlagManager")
@@ -29,7 +35,10 @@ class TwoFactorProviderRegistryTest extends \PHPUnit_Framework_TestCase
 
         $this->provider = $this->getMock("Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderInterface");
 
-        $this->registry = new TwoFactorProviderRegistry($this->flagManager, array('test' => $this->provider));
+        $this->collection = new TwoFactorProviderCollection();
+        $this->collection->addProvider('test', $this->provider);
+
+        $this->registry = new TwoFactorProviderRegistry($this->flagManager, $this->collection);
     }
 
     private function getToken()

--- a/Tests/Security/TwoFactor/VoterTest.php
+++ b/Tests/Security/TwoFactor/VoterTest.php
@@ -144,4 +144,38 @@ class VoterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(VoterInterface::ACCESS_ABSTAIN, $voter->vote($token, null, array()));
     }
+
+    /**
+     * @test
+     **/
+    public function voter_supportsClass()
+    {
+        $token = $this->getToken();
+
+        $sessionFlagManager = $this->getSessionFlagManager();
+        $providerCollection = $this->getProviderCollection();
+
+        $voter = $this->getVoter($providerCollection, $sessionFlagManager);
+
+        $returnValue = $voter->supportsClass('test');
+
+        $this->assertTrue($returnValue);
+    }
+
+    /**
+     * @test
+     **/
+    public function voter_supportsAttribute()
+    {
+        $token = $this->getToken();
+
+        $sessionFlagManager = $this->getSessionFlagManager();
+        $providerCollection = $this->getProviderCollection();
+
+        $voter = $this->getVoter($providerCollection, $sessionFlagManager);
+
+        $returnValue = $voter->supportsAttribute('test');
+
+        $this->assertTrue($returnValue);
+    }
 }

--- a/Tests/Security/TwoFactor/VoterTest.php
+++ b/Tests/Security/TwoFactor/VoterTest.php
@@ -1,0 +1,147 @@
+<?php
+namespace Scheb\TwoFactorBundle\Tests\Security\TwoFactor;
+
+use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderCollection;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Voter;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class VoterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $provider;
+
+    /**
+     * @var \Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderCollection
+     **/
+    protected $providerCollection;
+
+    /**
+        * @var \Scheb\TwoFactorBundle\Security\TwoFactor\Voter
+     **/
+    protected $voter;
+
+    public function setUp()
+    {
+        $this->provider = $this->getMock("Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderInterface");
+
+    }
+
+    private function getProviderCollection($providers = true)
+    {
+        $providerCollection = new TwoFactorProviderCollection();
+        if(true === $providers) {
+            $providerCollection->addProvider('test', $this->provider);
+        }
+
+        return $providerCollection;
+    }
+
+    private function getSessionFlagManager()
+    {
+        $sessionFlagManager = $this->getMockBuilder("Scheb\TwoFactorBundle\Security\TwoFactor\Session\SessionFlagManager")
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        return $sessionFlagManager;
+    }
+
+    private function getToken()
+    {
+        $token = $this->getMock("Symfony\Component\Security\Core\Authentication\Token\TokenInterface");
+
+        return $token;
+    }
+
+    private function getVoter($providerCollection, $sessionFlagManager)
+    {
+        $voter = new Voter($sessionFlagManager, $providerCollection);
+
+        return $voter;
+    }
+
+    /**
+     * @test
+     **/
+    public function vote_notAuthenticated_withProviders()
+    {
+        $token = $this->getToken();
+
+        $sessionFlagManager = $this->getSessionFlagManager();
+        $providerCollection = $this->getProviderCollection();
+
+        $sessionFlagManager
+            ->expects($this->once())
+            ->method("isNotAuthenticated")
+            ->with('test', $token)
+            ->will($this->returnValue(true));
+
+        $voter = $this->getVoter($providerCollection, $sessionFlagManager);
+
+        $this->assertEquals(VoterInterface::ACCESS_DENIED, $voter->vote($token, null, array()));
+    }
+
+    /**
+     * @test
+     **/
+    public function vote_notAuthenticated_noProviders()
+    {
+        $token = $this->getToken();
+
+        $sessionFlagManager = $this->getSessionFlagManager();
+        $providerCollection = $this->getProviderCollection(false);
+
+        $sessionFlagManager
+            ->expects($this->never())
+            ->method("isNotAuthenticated");
+
+        $voter = $this->getVoter($providerCollection, $sessionFlagManager);
+
+        $this->assertEquals(VoterInterface::ACCESS_ABSTAIN, $voter->vote($token, null, array()));
+    }
+
+    /**
+     * @test
+     **/
+    public function vote_authenticated_withProviders()
+    {
+        $token = $this->getToken();
+
+        $sessionFlagManager = $this->getSessionFlagManager();
+        $sessionFlagManager->setComplete('test', $token);
+
+        $providerCollection = $this->getProviderCollection();
+
+        $sessionFlagManager
+            ->expects($this->once())
+            ->method("isNotAuthenticated")
+            ->with('test', $token)
+            ->will($this->returnValue(false));
+
+        $voter = $this->getVoter($providerCollection, $sessionFlagManager);
+
+        $this->assertEquals(VoterInterface::ACCESS_ABSTAIN, $voter->vote($token, null, array()));
+    }
+
+    /**
+     * @test
+     **/
+    public function vote_authenticated_noProviders()
+    {
+        $token = $this->getToken();
+
+        $sessionFlagManager = $this->getSessionFlagManager();
+        $sessionFlagManager->setComplete('test', $token);
+
+        $providerCollection = $this->getProviderCollection(false);
+
+        $sessionFlagManager
+            ->expects($this->never())
+            ->method("isNotAuthenticated");
+
+        $voter = $this->getVoter($providerCollection, $sessionFlagManager);
+
+        $this->assertEquals(VoterInterface::ACCESS_ABSTAIN, $voter->vote($token, null, array()));
+    }
+}


### PR DESCRIPTION
This helps for example with creating layouts that check for the logged in user to display different content, like a menu on top. The Voter checks if the two-factor-auth is completed, if not it will deny access.

This requires `security.access_decisision_manager.strategy` set to `unanimous`