### PR TITLE
Added validation of excluded pattern at InteractiveLoginListener

### DIFF
--- a/Resources/config/listeners.xml
+++ b/Resources/config/listeners.xml
@@ -9,6 +9,7 @@
 			<tag name="kernel.event_listener" event="security.interactive_login" method="onSecurityInteractiveLogin" />
 			<argument type="service" id="scheb_two_factor.trusted_filter" />
 			<argument>%scheb_two_factor.security_tokens%</argument>
+			<argument>%scheb_two_factor.exclude_pattern%</argument>
 		</service>
 		<service id="scheb_two_factor.security.request_listener" class="%scheb_two_factor.security.request_listener.class%">
 			<tag name="kernel.event_listener" event="kernel.request" method="onCoreRequest" priority="-1" />

--- a/Security/TwoFactor/EventListener/InteractiveLoginListener.php
+++ b/Security/TwoFactor/EventListener/InteractiveLoginListener.php
@@ -19,15 +19,22 @@ class InteractiveLoginListener
     private $supportedTokens;
 
     /**
+     * @var string $excludePattern
+     */
+    private $excludePattern;
+
+    /**
      * Construct a listener for login events
      *
      * @param \Scheb\TwoFactorBundle\Security\TwoFactor\AuthenticationHandlerInterface $authHandler
      * @param array                                                                    $supportedTokens
+     * @param string                                                                   $excludePattern
      */
-    public function __construct(AuthenticationHandlerInterface $authHandler, array $supportedTokens)
+    public function __construct(AuthenticationHandlerInterface $authHandler, array $supportedTokens, $excludePattern = null)
     {
         $this->authHandler = $authHandler;
         $this->supportedTokens = $supportedTokens;
+        $this->excludePattern = $excludePattern;
     }
 
     /**
@@ -38,6 +45,11 @@ class InteractiveLoginListener
     public function onSecurityInteractiveLogin(InteractiveLoginEvent $event)
     {
         $request = $event->getRequest();
+
+        // Exclude path
+        if ($this->excludePattern !== null && preg_match("#".$this->excludePattern."#", $request->getPathInfo())) {
+            return;
+        }
 
         // Check if security token is supported
         $token = $event->getAuthenticationToken();

--- a/Tests/Security/TwoFactor/EventListener/InteractiveLoginListenerTest.php
+++ b/Tests/Security/TwoFactor/EventListener/InteractiveLoginListenerTest.php
@@ -87,4 +87,58 @@ class InteractiveLoginListenerTest extends \PHPUnit_Framework_TestCase
         $this->listener->onSecurityInteractiveLogin($event);
     }
 
+    /**
+     * @test
+     */
+    public function onSecurityInteractiveLogin_exclude_pattern_doNothing()
+    {
+        $excludedPattern = '^/(admin)/';
+        $this->authHandler = $this->getMock("Scheb\TwoFactorBundle\Security\TwoFactor\AuthenticationHandlerInterface");
+        $supportedTokens = array("Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken");
+        $this->listener = new InteractiveLoginListener($this->authHandler, $supportedTokens, $excludedPattern);
+
+        $token = new UsernamePasswordToken("user", array(), "key");
+        $event = $this->createEventWithExcludedPattern('/admin/login_check', $token);
+
+        //Expect TwoFactorProvider not to be called
+        $this->authHandler
+            ->expects($this->never())
+            ->method("beginAuthentication");
+        
+        $this->listener->onSecurityInteractiveLogin($event);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createEventWithExcludedPattern($pathInfo = "/some-path/", $token)
+    {
+        $this->request = $this->getMock("Symfony\Component\HttpFoundation\Request");
+        $this->request
+            ->expects($this->any())
+            ->method("getPathInfo")
+            ->will($this->returnValue($pathInfo));
+
+        $event = $this->getMockBuilder("Symfony\Component\Security\Http\Event\InteractiveLoginEvent")
+            ->disableOriginalConstructor()
+            ->getMock();
+        $event
+            ->expects($this->any())
+            ->method("getRequest")
+            ->will($this->returnValue($this->request));
+        $event
+            ->expects($this->any())
+            ->method("getAuthenticationToken")
+            ->will($this->returnValue($token));
+
+        return $event;
+    }
+
+    public function tearDown()
+    {
+        $this->listener = null;
+        $this->authHandler = null;
+        $this->request = null;
+    }
+
 }


### PR DESCRIPTION
Given the excluded_pattern: exclude_pattern: ^/(css|js|images|admin)/
While I'm able to access the admin area without problems, I still get an email/sms/etc with the auth code.
The InteractiveLoginListener is not validating the excludePattern so this includes this validation.