### PR TITLE
Make it possible to render the qr-code without google charts (e.g. with javascript)

### DIFF
--- a/Resources/doc/google.md
+++ b/Resources/doc/google.md
@@ -84,3 +84,11 @@ If a user entity has a secret code stored, you can generate a nice-looking QR co
 $url = $container->get("scheb_two_factor.security.google_authenticator")->getUrl($user);
 echo '<img src="'.$url.'" />';
 ```
+
+If you can't or don't want to use google charts to render the QR code you can also get the contents which need to be encoded in the QR code:
+
+```php
+$qrContent = $container->get("scheb_two_factor.security.google_authenticator")->getQRContent($user);
+```
+
+You can then encode $qrContent in a QR code the way you like (e.g. by using one of the many js-libraries)

--- a/Security/TwoFactor/Provider/Google/GoogleAuthenticator.php
+++ b/Security/TwoFactor/Provider/Google/GoogleAuthenticator.php
@@ -59,9 +59,23 @@ class GoogleAuthenticator
     public function getUrl(TwoFactorInterface $user)
     {
         $encoder = 'https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=';
+
+        return $encoder.urlencode($this->getQRContent($user));
+    }
+
+    /**
+     * Generate the content for a QR-Code to be scanned by Google Authenticator
+     * Use this method if you don't want to use google charts to display the qr-code
+     *
+     * @param TwoFactorInterface $user
+     *
+     * @return string
+     */
+    public function getQRContent(TwoFactorInterface $user)
+    {
         $userAndHost = rawurlencode($user->getUsername()).($this->server ? '@'.rawurlencode($this->server) : '');
         if ($this->issuer) {
-            $encoderURL = sprintf(
+            $qrContent = sprintf(
                 'otpauth://totp/%s:%s?secret=%s&issuer=%s',
                 rawurlencode($this->issuer),
                 $userAndHost,
@@ -69,14 +83,14 @@ class GoogleAuthenticator
                 rawurlencode($this->issuer)
             );
         } else {
-            $encoderURL = sprintf(
+            $qrContent = sprintf(
                 'otpauth://totp/%s?secret=%s',
                 $userAndHost,
                 $user->getGoogleAuthenticatorSecret()
             );
         }
 
-        return $encoder.urlencode($encoderURL);
+        return $qrContent;
     }
 
     /**


### PR DESCRIPTION
Hi there,

I just split the getUrl()-method in GoogleAuthenticator to make it possible to just get the content of the qr-code. Now it's possible to render the code without google charts (e.g. with another service like that or a js-library). 

Thank you for your work!

/Matthias