### PR TITLE
Added exception for `localhost` domain

### DIFF
--- a/Security/TwoFactor/Trusted/TrustedCookieManager.php
+++ b/Security/TwoFactor/Trusted/TrustedCookieManager.php
@@ -101,8 +101,14 @@ class TrustedCookieManager
         // Add token to user entity
         $this->trustedComputerManager->addTrustedComputer($user, $token, $validUntil);
 
+        $domain = null;
+        $requestHost = $request->getHost();
+        if ($requestHost !== 'localhost') {
+            $domain = '.' . $requestHost;
+        }
+
         // Create cookie
-        return new Cookie($this->cookieName, $tokenList, $validUntil, '/', '.' . $request->getHost(), $this->cookieSecure);
+        return new Cookie($this->cookieName, $tokenList, $validUntil, '/', $domain, $this->cookieSecure);
     }
 
     /**

--- a/Tests/Security/TwoFactor/Trusted/TrustedCookieManagerTest.php
+++ b/Tests/Security/TwoFactor/Trusted/TrustedCookieManagerTest.php
@@ -5,6 +5,7 @@ namespace Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Trusted;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Trusted\TrustedCookieManager;
 use Symfony\Component\HttpFoundation\Cookie;
 use Scheb\TwoFactorBundle\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 
 class TrustedCookieManagerTest extends TestCase
 {
@@ -185,6 +186,19 @@ class TrustedCookieManagerTest extends TestCase
             ->with($user, 'newTrustedCode');
 
         $this->cookieManager->createTrustedCookie($request, $user);
+    }
+
+    /**
+     * @test
+     */
+    public function createTrustedCookie_localhostSkippedInCookie()
+    {
+        $request = Request::create('');
+        $user = $this->createMock('Scheb\TwoFactorBundle\Model\TrustedComputerInterface');
+
+        $cookie = $this->cookieManager->createTrustedCookie($request, $user);
+
+        $this->assertNull($cookie->getDomain());
     }
 }
 


### PR DESCRIPTION
The current implementation unconditionally prepends a hostname with a dot, so it tries to set a cookie with `.localhost` domain, that would not be accepted by browsers.