### PR TITLE
Additionally check if trusted option is set by context

### DIFF
--- a/Security/TwoFactor/Trusted/TrustedFilter.php
+++ b/Security/TwoFactor/Trusted/TrustedFilter.php
@@ -57,13 +57,13 @@ class TrustedFilter implements AuthenticationHandlerInterface
     {
         $request = $context->getRequest();
         $user = $context->getUser();
+        $context->setUseTrustedOption($this->useTrustedOption);
 
         // Skip two-factor authentication on trusted computers
-        if ($this->useTrustedOption && $this->cookieManager->isTrustedComputer($request, $user)) {
+        if ($context->useTrustedOption() && $this->cookieManager->isTrustedComputer($request, $user)) {
             return;
         }
 
-        $context->setUseTrustedOption($this->useTrustedOption); // Set trusted flag
         $this->authHandler->beginAuthentication($context);
     }
 

--- a/Security/TwoFactor/Trusted/TrustedFilter.php
+++ b/Security/TwoFactor/Trusted/TrustedFilter.php
@@ -86,7 +86,7 @@ class TrustedFilter implements AuthenticationHandlerInterface
         if ($response instanceof Response) {
 
             // Set trusted cookie
-            if ($context->isAuthenticated() && $request->get($this->trustedName)) {
+            if ($context->isAuthenticated() && $context->useTrustedOption() && $request->get($this->trustedName)) {
                 $cookie = $this->cookieManager->createTrustedCookie($request, $user);
                 $response->headers->setCookie($cookie);
             }

--- a/Tests/Security/TwoFactor/Trusted/TrustedFilterTest.php
+++ b/Tests/Security/TwoFactor/Trusted/TrustedFilterTest.php
@@ -331,6 +331,11 @@ class TrustedFilterTest extends TestCase
             ->method('isAuthenticated')
             ->will($this->returnValue(true));
 
+        $context
+            ->expects($this->once())
+            ->method('useTrustedOption')
+            ->will($this->returnValue(true));
+
         //Stub the authentication handler
         $response = $this->getResponse();
         $this->authHandler
@@ -353,5 +358,35 @@ class TrustedFilterTest extends TestCase
             ->with($cookie);
 
         $this->trustedFilter->requestAuthenticationCode($context);
+    }
+
+    /**
+     * @test
+     */
+    public function requestAuthenticationCode_shouldCheckIfTrustedIsAllowedByContext()
+    {
+        $context = $this->getAuthenticationContext();
+
+        $context
+            ->expects($this->once())
+            ->method('isAuthenticated')
+            ->will($this->returnValue(true));
+
+        $context->expects($this->once())
+            ->method('useTrustedOption')
+            ->will($this->returnValue(false));
+
+        $this->authHandler
+            ->expects($this->once())
+            ->method('requestAuthenticationCode')
+            ->with($context)
+            ->will($this->returnValue(new Response('<form></form>')));
+
+        $this->cookieManager
+            ->expects($this->never())
+            ->method('createTrustedCookie');
+
+        $returnValue = $this->trustedFilter->requestAuthenticationCode($context);
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $returnValue);
     }
 }

--- a/Tests/Security/TwoFactor/Trusted/TrustedFilterTest.php
+++ b/Tests/Security/TwoFactor/Trusted/TrustedFilterTest.php
@@ -114,11 +114,46 @@ class TrustedFilterTest extends TestCase
         $user = $this->getUser();
         $context = $this->getAuthenticationContext();
 
+        $context
+            ->expects($this->once())
+            ->method('useTrustedOption')
+            ->will($this->returnValue(true));
+
         //Mock the TrustedCookieManager
         $this->cookieManager
             ->expects($this->once())
             ->method('isTrustedComputer')
             ->with($request, $user);
+
+        $this->authHandler
+            ->expects($this->once())
+            ->method('beginAuthentication');
+
+        $this->trustedFilter->beginAuthentication($context);
+    }
+
+    /**
+     * @test
+     */
+    public function beginAuthentication_trustedOptionUsedOnlyIfContextAllows()
+    {
+        $request = $this->getRequest();
+        $user = $this->getUser();
+        $context = $this->getAuthenticationContext();
+
+        $context
+            ->expects($this->once())
+            ->method('useTrustedOption')
+            ->will($this->returnValue(false));
+
+        $this->cookieManager
+            ->expects($this->never())
+            ->method('isTrustedComputer')
+            ->with($request, $user);
+
+        $this->authHandler
+            ->expects($this->once())
+            ->method('beginAuthentication');
 
         $this->trustedFilter->beginAuthentication($context);
     }
@@ -129,6 +164,11 @@ class TrustedFilterTest extends TestCase
     public function beginAuthentication_isTrustedComputer_notCallAuthenticationHandler()
     {
         $context = $this->getAuthenticationContext();
+
+        $context
+            ->expects($this->once())
+            ->method('useTrustedOption')
+            ->will($this->returnValue(true));
 
         //Stub the TrustedCookieManager
         $this->cookieManager


### PR DESCRIPTION
Otherwise it's possible to set it explicitly in the context and be trusted even when it should not have been

It is a fix for https://github.com/scheb/two-factor-bundle/issues/64