### PR TITLE
Dispatch events on Two Factor Authentication Success or Failure action

### DIFF
--- a/DependencyInjection/Compiler/ProviderCompilerPass.php
+++ b/DependencyInjection/Compiler/ProviderCompilerPass.php
@@ -33,7 +33,7 @@ class ProviderCompilerPass implements CompilerPassInterface
             $references[$name] = new Reference($id);
             $providerNames[] = $name;
         }
-        $registryDefinition->replaceArgument(1, $references);
+        $registryDefinition->replaceArgument(3, $references);
         $voterDefinition->replaceArgument(1, $providerNames);
     }
 }

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -42,7 +42,7 @@
 		<service id="scheb_two_factor.provider_registry" class="%scheb_two_factor.provider_registry.class%" lazy="true">
 			<argument type="service" id="scheb_two_factor.session_flag_manager" />
             <argument type="service" id="event_dispatcher" />
-            <argument type="string" id="%auth_code%" />
+            <argument>%scheb_two_factor.parameter_names.auth_code%</argument>
             <argument /> <!-- Two-factor providers -->
 		</service>
 		<service id="scheb_two_factor.backup_code_validator" class="%scheb_two_factor.backup_code_validator.class%">

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -41,7 +41,9 @@
 		</service>
 		<service id="scheb_two_factor.provider_registry" class="%scheb_two_factor.provider_registry.class%" lazy="true">
 			<argument type="service" id="scheb_two_factor.session_flag_manager" />
-			<argument /> <!-- Two-factor providers -->
+            <argument type="service" id="event_dispatcher" />
+            <argument type="string" id="%auth_code%" />
+            <argument /> <!-- Two-factor providers -->
 		</service>
 		<service id="scheb_two_factor.backup_code_validator" class="%scheb_two_factor.backup_code_validator.class%">
 			<argument type="service" id="scheb_two_factor.persister.doctrine" />

--- a/Security/TwoFactor/Event/TwoFactorAuthenticationEvent.php
+++ b/Security/TwoFactor/Event/TwoFactorAuthenticationEvent.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Scheb\TwoFactorBundle\Security\TwoFactor\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class TwoFactorAuthenticationEvent extends Event
+{
+}

--- a/Security/TwoFactor/Event/TwoFactorAuthenticationEvents.php
+++ b/Security/TwoFactor/Event/TwoFactorAuthenticationEvents.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Scheb\TwoFactorBundle\Security\TwoFactor\Event;
+
+class TwoFactorAuthenticationEvents
+{
+    const SUCCESS = 'scheb_two_factor.authentication.success';
+    const FAILURE = 'scheb_two_factor.authentication.failure';
+}

--- a/Security/TwoFactor/Provider/TwoFactorProviderRegistry.php
+++ b/Security/TwoFactor/Provider/TwoFactorProviderRegistry.php
@@ -93,10 +93,8 @@ class TwoFactorProviderRegistry implements AuthenticationHandlerInterface
                 if ($context->isAuthenticated()) {
                     $this->eventDispatcher->dispatch(TwoFactorAuthenticationEvents::SUCCESS, new TwoFactorAuthenticationEvent());
                     $this->flagManager->setComplete($providerName, $token);
-                } else {
-                    if ($context->getRequest()->request->has($this->authRequestParameter)) {
-                        $this->eventDispatcher->dispatch(TwoFactorAuthenticationEvents::FAILURE, new TwoFactorAuthenticationEvent());
-                    }
+                } else if ($context->getRequest()->request->has($this->authRequestParameter)) {
+                    $this->eventDispatcher->dispatch(TwoFactorAuthenticationEvents::FAILURE, new TwoFactorAuthenticationEvent());
                 }
 
                 // Return response

--- a/Tests/DependencyInjection/Compiler/ProviderCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ProviderCompilerPassTest.php
@@ -96,7 +96,7 @@ class ProviderCompilerPassTest extends TestCase
         $this->registryDefinition
             ->expects($this->once())
             ->method('replaceArgument')
-            ->with(1, array());
+            ->with(3, array());
         $this->voterDefinition
             ->expects($this->once())
             ->method('replaceArgument')
@@ -120,7 +120,7 @@ class ProviderCompilerPassTest extends TestCase
         $this->registryDefinition
             ->expects($this->once())
             ->method('replaceArgument')
-            ->with(1, array('providerAlias' => new Reference('serviceId')));
+            ->with(3, array('providerAlias' => new Reference('serviceId')));
         $this->voterDefinition
             ->expects($this->once())
             ->method('replaceArgument')


### PR DESCRIPTION
Due to some git flow mistakes and some developpement loked in my company, I create a new pull request from my repository (and not BLEUROY-HIGHCO)

I create TwoFactorAuthenticationEvents and TwoFactorAuthenticationEvent as asked in previous PR but I think that my implementation was more faithful with Symfony doc