### PR TITLE
Fix error with get_class() on PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - nightly
   - hhvm
 
 sudo: false
@@ -26,7 +28,7 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION=3.1.*
   allow_failures:
-    php: 7.0
+    - php: nightly
 
 cache:
   directories:

--- a/Security/TwoFactor/EventListener/InteractiveLoginListener.php
+++ b/Security/TwoFactor/EventListener/InteractiveLoginListener.php
@@ -83,6 +83,10 @@ class InteractiveLoginListener
      */
     private function isTokenSupported($token)
     {
+        if (null === $token) {
+            return false;
+        }
+
         $class = get_class($token);
 
         return in_array($class, $this->supportedTokens);

--- a/Security/TwoFactor/EventListener/RequestListener.php
+++ b/Security/TwoFactor/EventListener/RequestListener.php
@@ -98,6 +98,10 @@ class RequestListener
      */
     private function isTokenSupported($token)
     {
+        if (null === $token) {
+            return false;
+        }
+
         $class = get_class($token);
 
         return in_array($class, $this->supportedTokens);

--- a/Tests/Security/TwoFactor/EventListener/InteractiveLoginListenerTest.php
+++ b/Tests/Security/TwoFactor/EventListener/InteractiveLoginListenerTest.php
@@ -120,4 +120,20 @@ class InteractiveLoginListenerTest extends TestCase
 
         $this->listener->onSecurityInteractiveLogin($event);
     }
+
+    /**
+     * @test
+     */
+    public function onSecurityInteractiveLogin_NotLoggedInUser_notRequestAuthenticationCode()
+    {
+        // simulate a not logged in user
+        $event = $this->createEvent(null, self::NON_WHITELISTED_IP);
+
+        //Expect TwoFactorProvider not to be called
+        $this->authHandler
+            ->expects($this->never())
+            ->method('beginAuthentication');
+
+        $this->listener->onSecurityInteractiveLogin($event);
+    }
 }

--- a/Tests/Security/TwoFactor/EventListener/RequestListenerTest.php
+++ b/Tests/Security/TwoFactor/EventListener/RequestListenerTest.php
@@ -163,7 +163,24 @@ class RequestListenerTest extends TestCase
         $token = $this->createSupportedSecurityToken();
         $this->stubTokenStorage($token);
 
-        //Expect TwoFactorProvider to be called
+        //Expect TwoFactorProvider not to be called
+        $this->authHandler
+            ->expects($this->never())
+            ->method('requestAuthenticationCode');
+
+        $this->listener->onCoreRequest($event);
+    }
+
+    /**
+     * @test
+     */
+    public function onCoreRequest_NotLoggedInUser_notRequestAuthenticationCode()
+    {
+        $event = $this->createEvent();
+        // simulate a not logged in user
+        $this->stubTokenStorage(null);
+
+        //Expect TwoFactorProvider not to be called
         $this->authHandler
             ->expects($this->never())
             ->method('requestAuthenticationCode');


### PR DESCRIPTION
`get_class()` raise an error in PHP 7.2 when the given parameter isn't an object. And when a user isn't logged in, `getToken()` return `null`.

Here is a generated error without the fix: https://travis-ci.org/j0k3r/two-factor-bundle/jobs/171905928
We first spotted it on wallabag: https://travis-ci.org/wallabag/wallabag/jobs/171833498