### PR TITLE
Use Doctrine's more generic ObjectManager interface

### DIFF
--- a/Model/DoctrinePersister.php
+++ b/Model/DoctrinePersister.php
@@ -2,23 +2,23 @@
 
 namespace Scheb\TwoFactorBundle\Model;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\Common\Persistence\ObjectManager;
 
 class DoctrinePersister implements PersisterInterface
 {
     /**
-     * @var EntityManager
+     * @var ObjectManager
      */
-    private $em;
+    private $om;
 
     /**
      * Initialize a persister for doctrine entities.
      *
-     * @param EntityManager $em
+     * @param ObjectManager $om
      */
-    public function __construct(EntityManager $em)
+    public function __construct(ObjectManager $om)
     {
-        $this->em = $em;
+        $this->om = $om;
     }
 
     /**
@@ -28,7 +28,7 @@ class DoctrinePersister implements PersisterInterface
      */
     public function persist($user)
     {
-        $this->em->persist($user);
-        $this->em->flush();
+        $this->om->persist($user);
+        $this->om->flush();
     }
 }

--- a/Resources/config/persistence.xml
+++ b/Resources/config/persistence.xml
@@ -4,7 +4,7 @@
 		<parameter key="scheb_two_factor.persister.doctrine.class">Scheb\TwoFactorBundle\Model\DoctrinePersister</parameter>
 	</parameters>
 	<services>
-		<service id="scheb_two_factor.entity_manager" class="Doctrine\ORM\EntityManager" public="false">
+		<service id="scheb_two_factor.entity_manager" class="Doctrine\Common\Persistence\ObjectManager" public="false">
 			<factory service="doctrine" method="getManager" />
 			<argument>%scheb_two_factor.model_manager_name%</argument>
 		</service>

--- a/Tests/Model/DoctrinePersisterTest.php
+++ b/Tests/Model/DoctrinePersisterTest.php
@@ -19,6 +19,7 @@ class DoctrinePersisterTest extends TestCase
 
     public function setUp()
     {
+        // Although we use Doctrine's generic ObjectManager as an interface, for testing we will use Doctrine2 ORM's EntityManager
         $this->em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->setMethods(array('persist', 'flush'))


### PR DESCRIPTION
This would be a first step in allowing Doctrine2 ODM entities being used.

Besides, it weakens the EntityManager argument type, for people who are wrapping EntityManagers in some BC situations :].