### PR TITLE
don't require symfony/symfony instead its parts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,16 @@
         }
     ],
     "require": {
-        "symfony/symfony": "~2.6|~3.0",
+        "symfony/framework-bundle": "^2.6|^3.0|^4.0",
+        "symfony/console": "^2.6|^3.0|^4.0",
+        "symfony/config": "^2.6|^3.0|^4.0",
+        "symfony/http-kernel": "^2.6|^3.0|^4.0",
+        "symfony/dependency-injection": "^2.6|^3.0|^4.0",
+        "symfony/http-foundation": "^2.6|^3.0|^4.0",
+        "symfony/security-core": "^2.6|^3.0|^4.0",
+        "symfony/security-http": "^2.6|^3.0|^4.0",
+        "symfony/event-dispatcher": "^2.6|^3.0|^4.0",
+        "doctrine/common": "^2.4",
         "sonata-project/google-authenticator": "~1.0",
         "paragonie/random_compat": "~1.0|~2.0",
         "ocramius/proxy-manager": "~1.0|~2.0"


### PR DESCRIPTION
make it require only what is needed
Example:
https://github.com/FriendsOfSymfony/FOSRestBundle/blob/master/composer.json#L30-L47