### PR TITLE
fix wrong phpdoc in Google\TwoFactorInterface

### DIFF
--- a/Model/Google/TwoFactorInterface.php
+++ b/Model/Google/TwoFactorInterface.php
@@ -22,7 +22,7 @@ interface TwoFactorInterface
     /**
      * Set the Google Authenticator secret.
      *
-     * @param int $googleAuthenticatorSecret
+     * @param string|null $googleAuthenticatorSecret
      */
     public function setGoogleAuthenticatorSecret($googleAuthenticatorSecret);
 }


### PR DESCRIPTION
the `getGoogleAuthenticatorSecret` method has `string|null` as return type phpdoc, the setter had `int` as param, as far as I can tell `string|null` is correct and should be used for setter