### PR TITLE
Security Fix: set begin flag before calling provider

### DIFF
--- a/Security/TwoFactor/Provider/TwoFactorProviderRegistry.php
+++ b/Security/TwoFactor/Provider/TwoFactorProviderRegistry.php
@@ -65,8 +65,10 @@ class TwoFactorProviderRegistry implements AuthenticationHandlerInterface
     {
         /** @var TwoFactorProviderInterface $provider */
         foreach ($this->providers as $providerName => $provider) {
-            if ($provider->beginAuthentication($context)) {
-                $this->flagManager->setBegin($providerName, $context->getToken());
+            $this->flagManager->setBegin($providerName, $context->getToken());
+
+            if (!$provider->beginAuthentication($context)) {
+                $this->flagManager->setComplete($providerName, $context->getToken());
             }
         }
     }

--- a/Security/TwoFactor/Provider/TwoFactorProviderRegistry.php
+++ b/Security/TwoFactor/Provider/TwoFactorProviderRegistry.php
@@ -68,7 +68,7 @@ class TwoFactorProviderRegistry implements AuthenticationHandlerInterface
             $this->flagManager->setBegin($providerName, $context->getToken());
 
             if (!$provider->beginAuthentication($context)) {
-                $this->flagManager->setComplete($providerName, $context->getToken());
+                $this->flagManager->setAborted($providerName, $context->getToken());
             }
         }
     }

--- a/Security/TwoFactor/Session/SessionFlagManager.php
+++ b/Security/TwoFactor/Session/SessionFlagManager.php
@@ -42,6 +42,18 @@ class SessionFlagManager
     }
 
     /**
+     * Set session flag to abort two-factor authentication.
+     *
+     * @param string         $provider
+     * @param TokenInterface $token
+     */
+     public function setAborted($provider, $token)
+     {
+         $sessionFlag = $this->getSessionFlag($provider, $token);
+         $this->session->remove($sessionFlag);
+     }
+
+     /**
      * Set session flag completed.
      *
      * @param string         $provider

--- a/Tests/Security/TwoFactor/Provider/TwoFactorProviderRegistryTest.php
+++ b/Tests/Security/TwoFactor/Provider/TwoFactorProviderRegistryTest.php
@@ -146,8 +146,12 @@ class TwoFactorProviderRegistryTest extends TestCase
 
         //Mock the SessionFlagManager
         $this->flagManager
-            ->expects($this->never())
+            ->expects($this->once())
             ->method('setBegin');
+
+        $this->flagManager
+            ->expects($this->once())
+            ->method('setAborted');
 
         $this->registry->beginAuthentication($context);
     }

--- a/Tests/Security/TwoFactor/Session/SessionFlagManagerTest.php
+++ b/Tests/Security/TwoFactor/Session/SessionFlagManagerTest.php
@@ -78,6 +78,29 @@ class SessionFlagManagerTest extends TestCase
     /**
      * @test
      */
+    public function setComplete_abortTwoFactor_flagIsRemoved()
+    {
+        $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+
+        //Mock the SessionFlagGenerator
+        $this->flagGenerator
+            ->expects($this->once())
+            ->method('getSessionFlag')
+            ->with('providerName', $token)
+            ->willReturn('session_flag');
+
+        //Mock the Session
+        $this->session
+            ->expects($this->once())
+            ->method('remove')
+            ->with('session_flag');
+
+        $this->sessionFlagManager->setAborted('providerName', $token);
+    }
+
+    /**
+     * @test
+     */
     public function isNotAuthenticated_notSessionStarted_returnFalse()
     {
         $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');

--- a/Tests/Security/TwoFactor/Session/SessionFlagManagerTest.php
+++ b/Tests/Security/TwoFactor/Session/SessionFlagManagerTest.php
@@ -78,7 +78,7 @@ class SessionFlagManagerTest extends TestCase
     /**
      * @test
      */
-    public function setComplete_abortTwoFactor_flagIsRemoved()
+    public function setAborted_abortTwoFactor_flagIsRemoved()
     {
         $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
 


### PR DESCRIPTION
Hello @scheb 

I was experiencing a security issue in my Symfony app, this patch fixes it.

When calling `beginAuthentication` method on a custom provider, my application was throwing an exception because of a service inavailability my custom provider depends on (a cURL call was failing). Because the flag is set only following the method return value, no flag was set at this point.

The consequence is that the user was able to change the url and go to the application without completing double authentication. To avoid the error, I set the flag before calling the method so if the call never returns, the flag is set and the user cannot have access to the application.
