### PR TITLE
Break loop when ProviderCompilerPass is found

### DIFF
--- a/Tests/SchebTwoFactorBundleTest.php
+++ b/Tests/SchebTwoFactorBundleTest.php
@@ -21,7 +21,7 @@ class SchebTwoFactorBundleTest extends TestCase
         foreach ($containerBuilder->getCompilerPassConfig()->getPasses() as $pass) {
             if ($pass instanceof ProviderCompilerPass) {
                 $foundIt = true;
-                continue;
+                break;
             }
         }
 


### PR DESCRIPTION
When `ProviderCompilerPass` is found in `SchebTwoFactorBundleTest.php`, the loop can break to prevent unnecessary iterations. The current logic to `continue` anyway has no effect since the loop will normally continue 