### PR TITLE
Allow netmasks to be used in IP whitelist configuration

### DIFF
--- a/Resources/doc/configuration.md
+++ b/Resources/doc/configuration.md
@@ -53,9 +53,10 @@ scheb_two_factor:
     security_tokens:
         - Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken
 
-    # A list of IP addresses, which will not trigger two-factor authentication
+    # A list of IP addresses or netmasks, which will not trigger two-factor authentication
     ip_whitelist:
         - 127.0.0.1
+        - 192.168.0.0/16
 ```
 
 ```yaml

--- a/Security/TwoFactor/Handler/IpWhitelistHandler.php
+++ b/Security/TwoFactor/Handler/IpWhitelistHandler.php
@@ -3,6 +3,7 @@
 namespace Scheb\TwoFactorBundle\Security\TwoFactor\Handler;
 
 use Scheb\TwoFactorBundle\Security\TwoFactor\AuthenticationContextInterface;
+use Symfony\Component\HttpFoundation\IpUtils;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class IpWhitelistHandler implements AuthenticationHandlerInterface
@@ -28,7 +29,7 @@ class IpWhitelistHandler implements AuthenticationHandlerInterface
         $request = $context->getRequest();
 
         // Skip two-factor authentication for whitelisted IPs
-        if (in_array($request->getClientIp(), $this->ipWhitelist)) {
+        if (IpUtils::checkIp($request->getClientIp(), $this->ipWhitelist)) {
             return $context->getToken();
         }
 


### PR DESCRIPTION
In my opinion, it would make sense to allow for netmasks to be used in whitelist configuration, for example to allow skipping two-factor authentication from a certain office. Using Symfony utils' method for this.

Could not find a way to check tests, so did not alter them so far.