### PR TITLE
allow null value for google authenticator secret

### DIFF
--- a/Model/Google/TwoFactorInterface.php
+++ b/Model/Google/TwoFactorInterface.php
@@ -24,7 +24,7 @@ interface TwoFactorInterface
      *
      * @return string|null
      */
-    public function getGoogleAuthenticatorSecret(): string;
+    public function getGoogleAuthenticatorSecret(): ?string;
 
     /**
      * Set the Google Authenticator secret.


### PR DESCRIPTION
Hey guys, I just found a small bug in the google authenticator model while updating to your latest version.

The `getGoogleAuthenticatorSecret` method is not allowing null values to be returned but it will be a nullable property in most cases. The doc comment is already written to support null values.