### PR TITLE
Allow returning null for Guard authenticators

### DIFF
--- a/Security/Authentication/Provider/AuthenticationProviderDecorator.php
+++ b/Security/Authentication/Provider/AuthenticationProviderDecorator.php
@@ -63,7 +63,8 @@ class AuthenticationProviderDecorator implements AuthenticationProviderInterface
         $token = $this->decoratedAuthenticationProvider->authenticate($token);
 
         // AnonymousToken and TwoFactorToken can be ignored
-        if ($token instanceof AnonymousToken || $token instanceof TwoFactorToken) {
+        // in case of Guard, it can return null due to having multiple guard authenticators
+        if ($token instanceof AnonymousToken || $token instanceof TwoFactorToken || null === $token) {
             return $token;
         }
 

--- a/Tests/Security/Authentication/Provider/AuthenticationProviderDecoratorTest.php
+++ b/Tests/Security/Authentication/Provider/AuthenticationProviderDecoratorTest.php
@@ -71,7 +71,7 @@ class AuthenticationProviderDecoratorTest extends TestCase
         );
     }
 
-    private function stubDecoratedProviderReturnsToken(MockObject $token = null): void
+    private function stubDecoratedProviderReturnsToken(?MockObject $token): void
     {
         $this->decoratedAuthenticationProvider
             ->expects($this->any())

--- a/Tests/Security/Authentication/Provider/AuthenticationProviderDecoratorTest.php
+++ b/Tests/Security/Authentication/Provider/AuthenticationProviderDecoratorTest.php
@@ -71,7 +71,7 @@ class AuthenticationProviderDecoratorTest extends TestCase
         );
     }
 
-    private function stubDecoratedProviderReturnsToken(MockObject $token): void
+    private function stubDecoratedProviderReturnsToken(MockObject $token = null): void
     {
         $this->decoratedAuthenticationProvider
             ->expects($this->any())
@@ -153,6 +153,7 @@ class AuthenticationProviderDecoratorTest extends TestCase
         return [
             [$this->createMock(AnonymousToken::class)],
             [$this->createMock(TwoFactorToken::class)],
+            [null],
         ];
     }
 


### PR DESCRIPTION
Guard authenticators allow `null` as return during authentication. This can be triggered by having multiple firewalls with the same security context, but none of the authenticators trigger.

Edit: the actual fix for Symfony would solve it on their side, but that means I'd have to wait a while for a fix :sweat_smile: 