### PR TITLE
Only check POST requests for authentication attempts

### DIFF
--- a/Security/Http/Firewall/TwoFactorListener.php
+++ b/Security/Http/Firewall/TwoFactorListener.php
@@ -137,8 +137,11 @@ class TwoFactorListener implements ListenerInterface
 
         $request = $event->getRequest();
         if ($this->isCheckAuthCodeRequest($request)) {
-            $response = $this->attemptAuthentication($request, $currentToken);
-            $event->setResponse($response);
+            // Only attempt authentication on post requests (see https://github.com/symfony/symfony-docs/issues/6126)
+            if (Request::METHOD_POST === $request->getMethod()) {
+                $response = $this->attemptAuthentication($request, $currentToken);
+                $event->setResponse($response);
+            }
 
             return;
         }

--- a/Tests/Security/Http/Firewall/TwoFactorListenerTest.php
+++ b/Tests/Security/Http/Firewall/TwoFactorListenerTest.php
@@ -127,6 +127,10 @@ class TwoFactorListenerTest extends TestCase
             ->willReturnCallback(function (string $param) {
                 return $this->requestParams[$param];
             });
+        $this->request
+            ->expects($this->any())
+            ->method('getMethod')
+            ->willReturn(Request::METHOD_POST);
 
         $this->getResponseEvent = $this->createMock(GetResponseEvent::class);
         $this->getResponseEvent


### PR DESCRIPTION
https://github.com/symfony/symfony-docs/issues/6126 brought me to this PR.

Instead of configuring and implementing an empty `check_path` action in a controller it would be nice, if only authentication attempts will be made on `POST` requests. It will still work as before, but we can omit an additional check route:

```yaml
# config/packages/security.yaml
security:
    firewalls:
        yourFirewallName:
            # ...
            two_factor:
                auth_form_path: /2fa   # Path or route name of the two-factor form
                check_path: /2fa       # Path or route name of the two-factor code check
```
What do you think?