### PR TITLE
Fix googleAuthSecret mapping

### DIFF
--- a/Model/Google/TwoFactorInterface.php
+++ b/Model/Google/TwoFactorInterface.php
@@ -24,5 +24,5 @@ interface TwoFactorInterface
      *
      * @return string
      */
-    public function getGoogleAuthenticatorSecret(): string;
+    public function getGoogleAuthenticatorSecret(): ?string;
 }


### PR DESCRIPTION
Fix error where googleAuthenticaticatorSecret can be null in DB but not according to bundle
Return value of App\Entity\User::getGoogleAuthenticatorSecret() must be of the type string, null returned