### PR TITLE
Strip spaces from user given code

### DIFF
--- a/Security/TwoFactor/Provider/Google/GoogleAuthenticator.php
+++ b/Security/TwoFactor/Provider/Google/GoogleAuthenticator.php
@@ -31,6 +31,8 @@ class GoogleAuthenticator implements GoogleAuthenticatorInterface
 
     public function checkCode(TwoFactorInterface $user, string $code): bool
     {
+        // Strip any user added spaces
+        $code = str_replace(' ', '', $code);
         return $this->authenticator->checkCode($user->getGoogleAuthenticatorSecret(), $code);
     }
 


### PR DESCRIPTION
After some user testing we got the feedback that if the numbers are entered as they are shown in the Google Authenticator app with a space between the third and fourth number the code isn't valid. 

This PR will remove any spaces from user input before calling the actual authenticator for verification