### PR TITLE
fix typo in TwoFactorInterface comment

### DIFF
--- a/Model/Google/TwoFactorInterface.php
+++ b/Model/Google/TwoFactorInterface.php
@@ -20,7 +20,7 @@ interface TwoFactorInterface
 
     /**
      * Return the Google Authenticator secret
-     * When an empty string or null is returned, the Google authentication is disabled.
+     * When an empty string is returned, the Google authentication is disabled.
      *
      * @return string
      */


### PR DESCRIPTION
First I actually wanter to change the return type to `?string`, but after some investigation it makes sense to just change the comment.