### PR TITLE
The message key inside InvalidTwoFactorCodeException is now serialized

### DIFF
--- a/Security/Authentication/Exception/InvalidTwoFactorCodeException.php
+++ b/Security/Authentication/Exception/InvalidTwoFactorCodeException.php
@@ -20,4 +20,18 @@ class InvalidTwoFactorCodeException extends AuthenticationException
     {
         $this->messageKey = $messageKey;
     }
+
+    public function serialize()
+    {
+        return serialize(array(
+            $this->messageKey,
+            parent::serialize(),
+        ));
+    }
+
+    public function unserialize($str)
+    {
+        list($this->messageKey, $parentData) = unserialize($str);
+        parent::unserialize($parentData);
+    }
 }


### PR DESCRIPTION
I wanted to translate authentication errors, but the message key was getting lost during redirection. So I included it in serialization.