### PR TITLE
Allow using array keys with single nesting level as an auth code parameter and csrf token parameter

### DIFF
--- a/Security/Http/Firewall/TwoFactorListener.php
+++ b/Security/Http/Firewall/TwoFactorListener.php
@@ -8,6 +8,7 @@ use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenFactoryInt
 use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
 use Scheb\TwoFactorBundle\Security\Http\Authentication\AuthenticationRequiredHandlerInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Csrf\CsrfTokenValidator;
+use Scheb\TwoFactorBundle\Security\Http\ParameterBagUtils;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvent;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvents;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Trusted\TrustedDeviceManagerInterface;
@@ -191,7 +192,7 @@ class TwoFactorListener implements ListenerInterface
 
     private function getAuthCodeFromRequest(Request $request): string
     {
-        return $request->get($this->options['auth_code_parameter_name'], '');
+        return ParameterBagUtils::getRequestParameterValue($request, $this->options['auth_code_parameter_name']) ?? '';
     }
 
     private function attemptAuthentication(Request $request, TwoFactorTokenInterface $currentToken): Response

--- a/Security/Http/ParameterBagUtils.php
+++ b/Security/Http/ParameterBagUtils.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Scheb\TwoFactorBundle\Security\Http;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\PropertyAccess\Exception\AccessException;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
+class ParameterBagUtils
+{
+    private static $propertyAccessor;
+
+    /**
+     * @see Symfony\Component\Security\Http\ParameterBagUtils
+     *
+     * Returns a request "parameter" value.
+     *
+     * Paths like foo[bar] will be evaluated to find deeper items in nested data structures.
+     *
+     * @param Request $request The request
+     * @param string  $path    The key
+     *
+     * @return mixed
+     *
+     * @throws \InvalidArgumentException when the given path is malformed
+     */
+    public static function getRequestParameterValue(Request $request, $path)
+    {
+        if (false === $pos = strpos($path, '[')) {
+            return $request->get($path);
+        }
+
+        $root = substr($path, 0, $pos);
+
+        if (null === $value = $request->get($root)) {
+            return;
+        }
+
+        if (null === self::$propertyAccessor) {
+            self::$propertyAccessor = PropertyAccess::createPropertyAccessor();
+        }
+
+        try {
+            return self::$propertyAccessor->getValue($value, substr($path, $pos));
+        } catch (AccessException $e) {
+            return;
+        }
+    }
+
+}

--- a/Security/TwoFactor/Csrf/CsrfTokenValidator.php
+++ b/Security/TwoFactor/Csrf/CsrfTokenValidator.php
@@ -2,6 +2,7 @@
 
 namespace Scheb\TwoFactorBundle\Security\TwoFactor\Csrf;
 
+use Scheb\TwoFactorBundle\Security\Http\ParameterBagUtils;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
@@ -26,7 +27,7 @@ class CsrfTokenValidator
 
     public function hasValidCsrfToken(Request $request): bool
     {
-        $tokenValue = $request->request->get($this->options['csrf_parameter'], '');
+        $tokenValue = ParameterBagUtils::getRequestParameterValue($request, $this->options['csrf_parameter']);
         $token = new CsrfToken($this->options['csrf_token_id'], $tokenValue);
         if (!$this->csrfTokenGenerator->isTokenValid($token)) {
             return false;


### PR DESCRIPTION
As it's allowed in symfony's security component, it allows to use arrays keys as form parameter name
This will allow to use symfony form as a two factor authentication form

```yaml
two_factor:
                auth_form_path: admin_2fa_login
                check_path: admin_2fa_login_check
                auth_code_parameter_name: two_factor[auth_code]
                csrf_token_generator: security.csrf.token_manager
                csrf_parameter: two_factor[token]
                csrf_token_id: two_factor_secret
                default_target_path: admin_index
```