### PR TITLE
Allow null value for trusted device same site cookie setting

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,7 +28,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('cookie_same_site')
                             ->defaultValue('lax')
                             ->validate()
-                            ->ifNotInArray(['lax', 'strict'])
+                            ->ifNotInArray(['lax', 'strict', null])
                                 ->thenInvalid('Invalid cookie same-site value %s, must be "lax" or "strict"')
                             ->end()
                         ->end()

--- a/Resources/doc/configuration.md
+++ b/Resources/doc/configuration.md
@@ -15,7 +15,7 @@ scheb_two_factor:
         extend_lifetime: false         # Automatically extend lifetime of the trusted cookie on re-login
         cookie_name: trusted_device    # Name of the trusted device cookie
         cookie_secure: false           # Set the 'Secure' (HTTPS Only) flag on the trusted device cookie
-        cookie_same_site: "lax"        # The same-site option of the cookie, can be "lax" or "strict"
+        cookie_same_site: "lax"        # The same-site option of the cookie, can be "lax", "strict" or null
 
     # Backup codes feature
     backup_codes:

--- a/Security/TwoFactor/Trusted/TrustedCookieResponseListener.php
+++ b/Security/TwoFactor/Trusted/TrustedCookieResponseListener.php
@@ -28,7 +28,7 @@ class TrustedCookieResponseListener
     private $cookieSecure;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $cookieSameSite;
 
@@ -37,7 +37,7 @@ class TrustedCookieResponseListener
         int $trustedTokenLifetime,
         string $cookieName,
         bool $cookieSecure,
-        string $cookieSameSite
+        ?string $cookieSameSite
     ) {
         $this->trustedTokenStorage = $trustedTokenStorage;
         $this->trustedTokenLifetime = $trustedTokenLifetime;


### PR DESCRIPTION
As discussed in #161 this PR adds the possibility to explicitly specify null as same site setting for the trusted device cookie.