### PR TITLE
Fixes Symfony 4.2 deprecation messages (backwards compatible) 

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -9,8 +9,14 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('scheb_two_factor');
+        $treeBuilder = new TreeBuilder('scheb_two_factor');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('scheb_two_factor');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
Fixes:

* Deprecated constructing a TreeBuilder without passing root node information

See https://github.com/symfony/symfony/blob/master/UPGRADE-4.2.md