### PR TITLE
Allow getGoogleAuthentiactorSecret to return null

### DIFF
--- a/Model/Google/TwoFactorInterface.php
+++ b/Model/Google/TwoFactorInterface.php
@@ -20,9 +20,9 @@ interface TwoFactorInterface
 
     /**
      * Return the Google Authenticator secret
-     * When an empty string is returned, the Google authentication is disabled.
+     * When null or an empty string is returned, the Google authentication is disabled.
      *
-     * @return string
+     * @return string|null
      */
-    public function getGoogleAuthenticatorSecret(): string;
+    public function getGoogleAuthenticatorSecret(): ?string;
 }


### PR DESCRIPTION
The return type for the `getGoogleAuthenticatorSecret` method in the `TwoFactorInterface` was only ever allowed to return type `string`. This means that if the secret were to be unset, it must be an empty string.

This is not ideal as when every User object is created, they must be constructed such that the secret is populated with an empty string, otherwise exceptions will be thrown due to a mismatch return type.

I've extended the return type to `?string`, allowing null values to be returned, which is a reasonable expectation as when 2FA is not enabled for a user, the value in this field should be empty, and null is a perfectly valid value to represent empty. This eliminates the need to initialise every user with an empty string for their 2FA secret.

In the `composer.json` file, the minimum supported version was already PHP 7.1, which was the version of PHP that nullable return types were implemented, and therefore will not cause any incompatibility issues.