### PR TITLE
Allow the TrustedDevices cookies to be configured by domain 

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -31,6 +31,7 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('extend_lifetime')->defaultValue(false)->end()
                         ->scalarNode('cookie_name')->defaultValue('trusted_device')->end()
                         ->booleanNode('cookie_secure')->defaultValue(false)->end()
+                        ->scalarNode('cookie_domain')->defaultNull()->end()
                         ->scalarNode('cookie_same_site')
                             ->defaultValue('lax')
                             ->validate()

--- a/Resources/config/trusted_device.xml
+++ b/Resources/config/trusted_device.xml
@@ -18,6 +18,7 @@
 			<argument>%scheb_two_factor.trusted_device.cookie_name%</argument>
 			<argument>%scheb_two_factor.trusted_device.cookie_secure%</argument>
 			<argument>%scheb_two_factor.trusted_device.cookie_same_site%</argument>
+			<argument>%scheb_two_factor.trusted_device.cookie_domain%</argument>
 			<tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" />
 		</service>
 

--- a/Resources/doc/configuration.md
+++ b/Resources/doc/configuration.md
@@ -16,6 +16,7 @@ scheb_two_factor:
         cookie_name: trusted_device    # Name of the trusted device cookie
         cookie_secure: false           # Set the 'Secure' (HTTPS Only) flag on the trusted device cookie
         cookie_same_site: "lax"        # The same-site option of the cookie, can be "lax", "strict" or null
+        cookie_domain: ".example.com"  # Domain to use when setting the cookie, fallback to the request domain if not set
 
     # Backup codes feature
     backup_codes:

--- a/Resources/doc/trusted_device.md
+++ b/Resources/doc/trusted_device.md
@@ -16,6 +16,7 @@ scheb_two_factor:
         cookie_name: trusted_device    # Name of the trusted device cookie
         cookie_secure: false           # Set the 'Secure' (HTTPS Only) flag on the trusted device cookie
         cookie_same_site: "lax"        # The same-site option of the cookie, can be "lax" or "strict"
+        cookie_domain: ".example.com"  # Domain to use when setting the cookie, fallback to the request domain if not set
 ```
 
 Trusted device cookies are versioned, which gives you (or the user) to possibility to invalidate all trusted device

--- a/Security/TwoFactor/Trusted/TrustedCookieResponseListener.php
+++ b/Security/TwoFactor/Trusted/TrustedCookieResponseListener.php
@@ -32,27 +32,39 @@ class TrustedCookieResponseListener
      */
     private $cookieSameSite;
 
+    /**
+     * @var string|null
+     */
+    private $cookieDomain;
+
     public function __construct(
         TrustedDeviceTokenStorage $trustedTokenStorage,
         int $trustedTokenLifetime,
         string $cookieName,
         bool $cookieSecure,
-        ?string $cookieSameSite
+        ?string $cookieSameSite,
+        ?string $cookieDomain
     ) {
         $this->trustedTokenStorage = $trustedTokenStorage;
         $this->trustedTokenLifetime = $trustedTokenLifetime;
         $this->cookieName = $cookieName;
         $this->cookieSecure = $cookieSecure;
         $this->cookieSameSite = $cookieSameSite;
+        $this->cookieDomain = $cookieDomain;
     }
 
     public function onKernelResponse(FilterResponseEvent $event): void
     {
         if ($this->trustedTokenStorage->hasUpdatedCookie()) {
             $domain = null;
-            $requestHost = $event->getRequest()->getHost();
-            if ($this->shouldSetDomain($requestHost)) {
-                $domain = '.'.$requestHost;
+
+            if ($this->cookieDomain !== null) {
+                $domain = $this->cookieDomain;
+            } else {
+                $requestHost = $event->getRequest()->getHost();
+                if ($this->shouldSetDomain($requestHost)) {
+                    $domain = '.'.$requestHost;
+                }
             }
 
             // Set the cookie

--- a/Tests/Security/TwoFactor/Trusted/TrustedCookieResponseListenerTest.php
+++ b/Tests/Security/TwoFactor/Trusted/TrustedCookieResponseListenerTest.php
@@ -134,6 +134,41 @@ class TrustedCookieResponseListenerTest extends TestCase
 
     /**
      * @test
+     */
+    public function onKernelResponse_setCookieDomain(): void
+    {
+        $domain = '.test.me';
+
+        $this->cookieResponseListener = new TestableTrustedCookieResponseListener($this->trustedTokenStorage,
+        3600, 'cookieName', true, Cookie::SAMESITE_LAX, $domain);
+        $this->cookieResponseListener->now = new \DateTime('2018-01-01 00:00:00');
+
+        $this->trustedTokenStorage
+            ->expects($this->once())
+            ->method('hasUpdatedCookie')
+            ->willReturn(true);
+
+        $event = $this->createEvent();
+        $this->cookieResponseListener->onKernelResponse($event);
+        $cookies = $this->response->headers->getCookies();
+        $this->assertCount(1, $cookies, 'Response must have a cookie set.');
+
+        $expectedCookie = new Cookie(
+            'cookieName',
+            null,
+            new \DateTime('2018-01-01 01:00:00'),
+            '/',
+            $domain,
+            true,
+            true,
+            false,
+            Cookie::SAMESITE_LAX
+        );
+        $this->assertEquals($expectedCookie, $cookies[0]);
+    }
+
+    /**
+     * @test
      * @dataProvider provideRequestHostName
      */
     public function onKernelResponse_excludedHostNames_notSetDomain(string $requestHostName): void


### PR DESCRIPTION
Allow the TrustedDevices cookies to be configured by domain , or fallback to the default request domain if not set.