### PR TITLE
Fixed couple unit tests inconsistencies and typse

### DIFF
--- a/Tests/Mailer/AuthCodeMailerTest.php
+++ b/Tests/Mailer/AuthCodeMailerTest.php
@@ -41,7 +41,7 @@ class AuthCodeMailerTest extends TestCase
         $user
             ->expects($this->any())
             ->method('getEmailAuthCode')
-            ->willReturn(1234);
+            ->willReturn('1234');
 
         $messageValidator = function ($mail) {
             /* @var \Swift_Message $mail */

--- a/Tests/Security/TwoFactor/Handler/TrustedDeviceHandlerTest.php
+++ b/Tests/Security/TwoFactor/Handler/TrustedDeviceHandlerTest.php
@@ -92,7 +92,7 @@ class TrustedDeviceHandlerTest extends AuthenticationHandlerTestCase
         $this->trustedDeviceManager
             ->expects($this->once())
             ->method('addTrustedDevice')
-            ->willReturn($user, 'firewallName');
+            ->with($user, 'firewallName');
 
         $trustedHandler->beginTwoFactorAuthentication($context);
     }


### PR DESCRIPTION
I noticed couple inconsistencies in unit tests:

1. `TwoFactorInterface::getEmailAuthCode` returns a string not a number
1. `willReturn` was confused with `with`

Both were reported as a warning in phpunit when is run under php7.2:

```
There were 2 warnings:

1) Scheb\TwoFactorBundle\Tests\Mailer\AuthCodeMailerTest::sendAuthCode_withUserObject_sendEmail
Method getEmailAuthCode may not return value of type integer

2) Scheb\TwoFactorBundle\Tests\Security\TwoFactor\Handler\TrustedDeviceHandlerTest::beginAuthentication_isTrustedDeviceAndExtendTrustedToken_addNewTrustedToken
Method addTrustedDevice may not return value of type object
```