### PR TITLE
Adjust require event triggers

### DIFF
--- a/Resources/config/two_factor.xml
+++ b/Resources/config/two_factor.xml
@@ -46,7 +46,9 @@
 
 		<service id="scheb_two_factor.provider_preparation_listener" class="\Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderPreparationListener">
 			<argument type="service" id="scheb_two_factor.provider_registry" />
+			<argument type="service" id="session" />
 			<tag name="kernel.event_listener" event="scheb_two_factor.authentication.require" method="onTwoFactorAuthenticationRequest" />
+			<tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" />
 		</service>
 
 		<!-- Alias for auto-wiring -->

--- a/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
+++ b/Security/TwoFactor/Provider/TwoFactorProviderPreparationListener.php
@@ -6,25 +6,53 @@ namespace Scheb\TwoFactorBundle\Security\TwoFactor\Provider;
 
 use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorToken;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvent;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 
 class TwoFactorProviderPreparationListener
 {
+    private const CALLED_PROVIDERS_SESSION_KEY = '2fa_called_providers';
+
     /**
      * @var TwoFactorProviderRegistry
      */
     private $providerRegistry;
 
-    public function __construct(TwoFactorProviderRegistry $providerRegistry)
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * @var TwoFactorToken|null
+     */
+    private $twoFactorToken;
+
+    public function __construct(TwoFactorProviderRegistry $providerRegistry, SessionInterface $session)
     {
         $this->providerRegistry = $providerRegistry;
+        $this->session = $session;
     }
 
     public function onTwoFactorAuthenticationRequest(TwoFactorAuthenticationEvent $event)
     {
-        /** @var TwoFactorToken $token */
-        $token = $event->getToken();
-        $user = $token->getUser();
-        $providerName = $token->getCurrentTwoFactorProvider();
+        $this->twoFactorToken = $event->getToken();
+    }
+
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        if (!$this->twoFactorToken instanceof TwoFactorToken) {
+            return;
+        }
+
+        $user = $this->twoFactorToken->getUser();
+        $providerName = $this->twoFactorToken->getCurrentTwoFactorProvider();
+        $calledProviders = $this->session->get(self::CALLED_PROVIDERS_SESSION_KEY, []);
+        if (in_array($providerName, $calledProviders, true)) {
+            return;
+        }
+        $calledProviders[] = $providerName;
+        $this->session->set(self::CALLED_PROVIDERS_SESSION_KEY, $calledProviders);
         $this->providerRegistry->getProvider($providerName)->prepareAuthentication($user);
     }
 }

--- a/Tests/Security/Http/Firewall/TwoFactorListenerTest.php
+++ b/Tests/Security/Http/Firewall/TwoFactorListenerTest.php
@@ -363,15 +363,13 @@ class TwoFactorListenerTest extends TestCase
     /**
      * @test
      */
-    public function handle_neitherFormNorCheckPath_dispatchRequireEvent(): void
+    public function handle_neitherFormNorCheckPath_doNothing(): void
     {
         $this->stubTokenManagerHasToken($this->createTwoFactorToken());
         $this->stubCurrentPath('/some_other_path');
         $this->stubPathAccessGranted(false);
 
-        $this->assertEventsDispatched([
-            TwoFactorAuthenticationEvents::REQUIRE,
-        ]);
+        $this->assertNoResponseSet();
 
         $this->listener->handle($this->getResponseEvent);
     }
@@ -399,6 +397,9 @@ class TwoFactorListenerTest extends TestCase
         $this->stubCurrentPath(self::FORM_PATH);
 
         $this->assertNoResponseSet();
+        $this->assertEventsDispatched([
+            TwoFactorAuthenticationEvents::REQUIRE,
+        ]);
 
         $this->listener->handle($this->getResponseEvent);
     }
@@ -502,7 +503,6 @@ class TwoFactorListenerTest extends TestCase
         $this->assertEventsDispatched([
             TwoFactorAuthenticationEvents::ATTEMPT,
             TwoFactorAuthenticationEvents::SUCCESS,
-            $this->anything(),
         ]);
 
         $this->listener->handle($this->getResponseEvent);
@@ -543,7 +543,6 @@ class TwoFactorListenerTest extends TestCase
         $this->assertEventsDispatched([
             TwoFactorAuthenticationEvents::ATTEMPT,
             TwoFactorAuthenticationEvents::SUCCESS,
-            TwoFactorAuthenticationEvents::REQUIRE,
         ]);
 
         $this->listener->handle($this->getResponseEvent);


### PR DESCRIPTION
Fixes #212 

To solve this issue, I simply move the `preferProvider` parameter logic onto the listener two trigger the event.

Fixes #223 

I used the session for that. It register the called provider to not call it again if it was called before.

This is the simpler way I found to fix the both issues without BC break. If it ok to you, I think it could be be release as a patch for 4.x. :+1: 

Please give me your feedback! :-)
