### PR TITLE
reorder dispatch() arguments

### DIFF
--- a/Security/Http/Firewall/TwoFactorListener.php
+++ b/Security/Http/Firewall/TwoFactorListener.php
@@ -16,6 +16,7 @@ use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvent;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvents;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Trusted\TrustedDeviceManagerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -251,6 +252,12 @@ class TwoFactorListener implements ListenerInterface
     private function dispatchTwoFactorAuthenticationEvent(string $eventType, Request $request, TokenInterface $token): void
     {
         $event = new TwoFactorAuthenticationEvent($request, $token);
-        $this->eventDispatcher->dispatch($eventType, $event);
+
+        // Symfony < 4.3
+        if (class_exists(LegacyEventDispatcherProxy::class)) {
+            $this->eventDispatcher->dispatch($event, $eventType);
+        } else {
+            $this->eventDispatcher->dispatch($eventType, $event);
+        }
     }
 }

--- a/Tests/Security/Http/Firewall/TwoFactorListenerTest.php
+++ b/Tests/Security/Http/Firewall/TwoFactorListenerTest.php
@@ -18,6 +18,7 @@ use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvents
 use Scheb\TwoFactorBundle\Security\TwoFactor\Trusted\TrustedDeviceManagerInterface;
 use Scheb\TwoFactorBundle\Tests\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -307,7 +308,12 @@ class TwoFactorListenerTest extends TestCase
         $numEvents = count($eventTypes);
         $consecutiveParams = [];
         foreach ($eventTypes as $eventType) {
-            $consecutiveParams[] = [$eventType, $this->isInstanceOf(TwoFactorAuthenticationEvent::class)];
+            // Symfony < 4.3
+            if (class_exists(LegacyEventDispatcherProxy::class)) {
+                $consecutiveParams[] = [$this->isInstanceOf(TwoFactorAuthenticationEvent::class), $eventType];
+            } else {
+                $consecutiveParams[] = [$eventType, $this->isInstanceOf(TwoFactorAuthenticationEvent::class)];
+            }
         }
         $this->eventDispatcher
             ->expects($this->exactly($numEvents))


### PR DESCRIPTION
Fix #225 :  Order of EventDispatcher::dispatch arguments