### PR TITLE
Forward any non-implemented method call to decorated services

### DIFF
--- a/Security/Authentication/Provider/AuthenticationProviderDecorator.php
+++ b/Security/Authentication/Provider/AuthenticationProviderDecorator.php
@@ -87,4 +87,9 @@ class AuthenticationProviderDecorator implements AuthenticationProviderInterface
 
         return $this->twoFactorAuthenticationHandler->beginTwoFactorAuthentication($context);
     }
+
+    public function __call($method, $arguments)
+    {
+        return ($this->decoratedAuthenticationProvider)->{$method}(...$arguments);
+    }
 }

--- a/Security/Authentication/RememberMe/RememberMeServicesDecorator.php
+++ b/Security/Authentication/RememberMe/RememberMeServicesDecorator.php
@@ -51,4 +51,9 @@ class RememberMeServicesDecorator implements RememberMeServicesInterface, Logout
     {
         $this->decoratedRememberMeServices->logout($request, $response, $token);
     }
+
+    public function __call($method, $arguments)
+    {
+        return ($this->decoratedRememberMeServices)->{$method}(...$arguments);
+    }
 }


### PR DESCRIPTION
To avoid breaking an implementation which exposes more methods (common in case of multi-level decoration for instance)