### PR TITLE
Entity method name corrected

### DIFF
--- a/Resources/doc/providers/totp.md
+++ b/Resources/doc/providers/totp.md
@@ -49,7 +49,7 @@ class User implements UserInterface, TwoFactorInterface
 
     // [...]    
 
-    public function isTotpAuthenticatorEnabled(): bool
+    public function isTotpAuthenticationEnabled(): bool
     {
         return $this->totpSecret ? true : false;
     }


### PR DESCRIPTION
I think it should be `isTotpAuthenticationEnabled` instead of `isTotpAuthenticatorEnabled`, according to `TwoFactorInterface`.