### PR TITLE
fix documentation

### DIFF
--- a/Resources/doc/providers/totp.md
+++ b/Resources/doc/providers/totp.md
@@ -42,6 +42,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Scheb\TwoFactorBundle\Model\Totp\TotpConfiguration;
 use Scheb\TwoFactorBundle\Model\Totp\TwoFactorInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Scheb\TwoFactorBundle\Model\Totp\TotpConfigurationInterface;
 
 class User implements UserInterface, TwoFactorInterface
 {


### PR DESCRIPTION
Add missing class.

Without this change in the docs you get this error:

<img width="1098" alt="Screenshot 2020-05-27 at 22 20 35" src="https://user-images.githubusercontent.com/400092/83073461-659c3380-a068-11ea-97f2-f63dda628b40.png">
