### PR TITLE
Fix email authentication documentation

### DIFF
--- a/Resources/doc/providers/email.md
+++ b/Resources/doc/providers/email.md
@@ -6,7 +6,7 @@ Email Authentication
 Install the mailer component:
 
 ```bash
-composer require mailer
+composer require symfony/swiftmailer-bundle
 ```
 
 ## How it works


### PR DESCRIPTION
With version 4.x, the required bundle for email authentication is `symfony/swiftmailer-bundle` instead of `mailer`